### PR TITLE
Journal Performance Tuning

### DIFF
--- a/JournalCoreData/Model Controllers/CoreDataImporter.swift
+++ b/JournalCoreData/Model Controllers/CoreDataImporter.swift
@@ -16,6 +16,7 @@ class CoreDataImporter {
     
     func sync(entries: [EntryRepresentation], completion: @escaping (Error?) -> Void = { _ in }) {
         
+        let start = CFAbsoluteTimeGetCurrent()
         self.context.perform {
             for entryRep in entries {
                 guard let identifier = entryRep.identifier else { continue }
@@ -27,6 +28,9 @@ class CoreDataImporter {
                     _ = Entry(entryRepresentation: entryRep, context: self.context)
                 }
             }
+            let end = CFAbsoluteTimeGetCurrent() - start
+            // Add print statement after syncing finishes
+            print("Syncing complete. Duration: \(end) seconds")
             completion(nil)
         }
     }

--- a/JournalCoreData/Model Controllers/EntryController.swift
+++ b/JournalCoreData/Model Controllers/EntryController.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CoreData
 
-let baseURL = URL(string: "https://journal-performance2.firebaseio.com/")!
+let baseURL = URL(string: "https://journal-a1cc9.firebaseio.com/")!
 
 class EntryController {
         


### PR DESCRIPTION
This pull request is part of the work required to improve the performance of **Journal** with large data sets. To achieve this we used Instruments to observe the CPU usage and slowdown points in the app at runtime. I added a print statement and clocked the time for synchronization to complete, and it took around ~243 seconds. The network request didn't seem slow, as Firebase updated entries right away. We were given two hints as to what could be causing the performance hit:

**Hint 1**
Fetch request predicates can use the `IN` operator to check for a value in an array. e.g. `NSPredicate("identifier IN %@", arrayOfIdentifiers)`.

**Hint 2**
Looking up values in a dictionary given a key is quite fast. Even with a large dictionary, `let value = dictionary[key]` will be efficient. Can you use this in your code to improve performance? 

I created a dictionary of the entries and their identifiers and refactored the `fetchSingleEntryPersistentStore()` method to use the IN operator to check the array of dictionaries for matching identifiers. After making those changes, the CPU usage was reduced dramatically.

</br>

(cc/ @jWarrenDev for feedback and suggestions)